### PR TITLE
rebuild requirements

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -7,7 +7,6 @@ aiohappyeyeballs==2.4.3
 aiohttp==3.10.10
     # via
     #   aiobotocore
-    #   delphi-epidata
     #   s3fs
 aioitertools==0.12.0
     # via aiobotocore
@@ -19,31 +18,16 @@ attrs==24.2.0
     #   pymmwr
 botocore==1.35.36
     # via aiobotocore
-certifi==2024.8.30
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.0
-    # via requests
 contourpy==1.3.0
     # via matplotlib
 coverage==7.6.4
     # via idmodels (pyproject.toml)
-covidcast==0.1.5
-    # via sarix
 cycler==0.12.1
     # via matplotlib
-delphi-epidata==4.1.25
-    # via covidcast
-descartes==1.1.0
-    # via covidcast
 distlib==0.3.9
     # via virtualenv
-epiweeks==2.3.0
-    # via covidcast
 filelock==3.16.1
     # via virtualenv
 fonttools==4.54.1
@@ -54,20 +38,12 @@ frozenlist==1.5.0
     #   aiosignal
 fsspec==2024.10.0
     # via s3fs
-geopandas==1.0.1
-    # via covidcast
 iddata @ git+https://github.com/reichlab/iddata@34751de1d155637ae93c4ddc35886dd8102e56ef
     # via idmodels (pyproject.toml)
 identify==2.6.1
     # via pre-commit
 idna==3.10
-    # via
-    #   requests
-    #   yarl
-imageio==2.36.0
-    # via covidcast
-imageio-ffmpeg==0.5.1
-    # via covidcast
+    # via yarl
 iniconfig==2.0.0
     # via pytest
 jax==0.4.35
@@ -89,10 +65,7 @@ lightgbm==4.5.0
 markdown-it-py==3.0.0
     # via rich
 matplotlib==3.9.2
-    # via
-    #   covidcast
-    #   descartes
-    #   sarix
+    # via sarix
 mdurl==0.1.2
     # via markdown-it-py
 ml-dtypes==0.5.0
@@ -111,10 +84,7 @@ numpy==2.1.3
     # via
     #   idmodels (pyproject.toml)
     #   contourpy
-    #   covidcast
-    #   geopandas
     #   iddata
-    #   imageio
     #   jax
     #   jaxlib
     #   lightgbm
@@ -122,11 +92,9 @@ numpy==2.1.3
     #   ml-dtypes
     #   numpyro
     #   pandas
-    #   pyogrio
     #   sarix
     #   scikit-learn
     #   scipy
-    #   shapely
     #   timeseriesutils
 numpyro==0.15.3
     # via sarix
@@ -134,22 +102,16 @@ opt-einsum==3.4.0
     # via jax
 packaging==24.1
     # via
-    #   geopandas
     #   matplotlib
-    #   pyogrio
     #   pytest
 pandas==2.2.3
     # via
     #   idmodels (pyproject.toml)
-    #   covidcast
-    #   geopandas
     #   iddata
     #   sarix
     #   timeseriesutils
 pillow==11.0.0
-    # via
-    #   imageio
-    #   matplotlib
+    # via matplotlib
 platformdirs==4.3.6
     # via virtualenv
 pluggy==1.5.0
@@ -162,12 +124,8 @@ pygments==2.18.0
     # via rich
 pymmwr==0.2.2
     # via iddata
-pyogrio==0.10.0
-    # via geopandas
 pyparsing==3.2.0
     # via matplotlib
-pyproj==3.7.0
-    # via geopandas
 pytest==8.3.3
     # via idmodels (pyproject.toml)
 python-dateutil==2.9.0.post0
@@ -179,17 +137,13 @@ pytz==2024.2
     # via pandas
 pyyaml==6.0.2
     # via pre-commit
-requests==2.32.3
-    # via
-    #   covidcast
-    #   delphi-epidata
 rich==13.9.4
     # via iddata
 ruff==0.7.2
     # via idmodels (pyproject.toml)
 s3fs==2024.10.0
     # via iddata
-sarix @ git+https://github.com/elray1/sarix@61a651c8ab5f09b0509a1cecbda4e7cefb42e8cc
+sarix @ git+https://github.com/elray1/sarix@1c8995942d49afbb66637f0dc0662e1248606af4
     # via idmodels (pyproject.toml)
 scikit-learn==1.5.2
     # via idmodels (pyproject.toml)
@@ -200,14 +154,8 @@ scipy==1.14.1
     #   lightgbm
     #   scikit-learn
     #   timeseriesutils
-setuptools==75.3.0
-    # via imageio-ffmpeg
-shapely==2.0.6
-    # via geopandas
 six==1.16.0
     # via python-dateutil
-tenacity==9.0.0
-    # via delphi-epidata
 threadpoolctl==3.5.0
     # via scikit-learn
 timeseriesutils @ git+https://github.com/reichlab/timeseriesutils@d25f33db30a8d5252329269ec9d205984f980f6c
@@ -217,14 +165,11 @@ toml==0.10.2
 tqdm==4.67.0
     # via
     #   idmodels (pyproject.toml)
-    #   covidcast
     #   numpyro
 tzdata==2024.2
     # via pandas
 urllib3==2.2.3
-    # via
-    #   botocore
-    #   requests
+    # via botocore
 virtualenv==20.27.1
     # via pre-commit
 wrapt==1.16.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,6 @@ aiohappyeyeballs==2.4.3
 aiohttp==3.10.10
     # via
     #   aiobotocore
-    #   delphi-epidata
     #   s3fs
 aioitertools==0.12.0
     # via aiobotocore
@@ -19,25 +18,10 @@ attrs==24.2.0
     #   pymmwr
 botocore==1.35.36
     # via aiobotocore
-certifi==2024.8.30
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
-charset-normalizer==3.4.0
-    # via requests
 contourpy==1.3.0
     # via matplotlib
-covidcast==0.1.5
-    # via sarix
 cycler==0.12.1
     # via matplotlib
-delphi-epidata==4.1.25
-    # via covidcast
-descartes==1.1.0
-    # via covidcast
-epiweeks==2.3.0
-    # via covidcast
 fonttools==4.54.1
     # via matplotlib
 frozenlist==1.5.0
@@ -46,18 +30,10 @@ frozenlist==1.5.0
     #   aiosignal
 fsspec==2024.10.0
     # via s3fs
-geopandas==1.0.1
-    # via covidcast
 iddata @ git+https://github.com/reichlab/iddata@34751de1d155637ae93c4ddc35886dd8102e56ef
     # via idmodels (pyproject.toml)
 idna==3.10
-    # via
-    #   requests
-    #   yarl
-imageio==2.36.0
-    # via covidcast
-imageio-ffmpeg==0.5.1
-    # via covidcast
+    # via yarl
 jax==0.4.35
     # via
     #   numpyro
@@ -77,10 +53,7 @@ lightgbm==4.5.0
 markdown-it-py==3.0.0
     # via rich
 matplotlib==3.9.2
-    # via
-    #   covidcast
-    #   descartes
-    #   sarix
+    # via sarix
 mdurl==0.1.2
     # via markdown-it-py
 ml-dtypes==0.5.0
@@ -97,10 +70,7 @@ numpy==2.1.3
     # via
     #   idmodels (pyproject.toml)
     #   contourpy
-    #   covidcast
-    #   geopandas
     #   iddata
-    #   imageio
     #   jax
     #   jaxlib
     #   lightgbm
@@ -108,45 +78,32 @@ numpy==2.1.3
     #   ml-dtypes
     #   numpyro
     #   pandas
-    #   pyogrio
     #   sarix
     #   scikit-learn
     #   scipy
-    #   shapely
     #   timeseriesutils
 numpyro==0.15.3
     # via sarix
 opt-einsum==3.4.0
     # via jax
 packaging==24.1
-    # via
-    #   geopandas
-    #   matplotlib
-    #   pyogrio
+    # via matplotlib
 pandas==2.2.3
     # via
     #   idmodels (pyproject.toml)
-    #   covidcast
-    #   geopandas
     #   iddata
     #   sarix
     #   timeseriesutils
 pillow==11.0.0
-    # via
-    #   imageio
-    #   matplotlib
+    # via matplotlib
 propcache==0.2.0
     # via yarl
 pygments==2.18.0
     # via rich
 pymmwr==0.2.2
     # via iddata
-pyogrio==0.10.0
-    # via geopandas
 pyparsing==3.2.0
     # via matplotlib
-pyproj==3.7.0
-    # via geopandas
 python-dateutil==2.9.0.post0
     # via
     #   botocore
@@ -154,15 +111,11 @@ python-dateutil==2.9.0.post0
     #   pandas
 pytz==2024.2
     # via pandas
-requests==2.32.3
-    # via
-    #   covidcast
-    #   delphi-epidata
 rich==13.9.4
     # via iddata
 s3fs==2024.10.0
     # via iddata
-sarix @ git+https://github.com/elray1/sarix@61a651c8ab5f09b0509a1cecbda4e7cefb42e8cc
+sarix @ git+https://github.com/elray1/sarix@1c8995942d49afbb66637f0dc0662e1248606af4
     # via idmodels (pyproject.toml)
 scikit-learn==1.5.2
     # via idmodels (pyproject.toml)
@@ -173,14 +126,8 @@ scipy==1.14.1
     #   lightgbm
     #   scikit-learn
     #   timeseriesutils
-setuptools==75.3.0
-    # via imageio-ffmpeg
-shapely==2.0.6
-    # via geopandas
 six==1.16.0
     # via python-dateutil
-tenacity==9.0.0
-    # via delphi-epidata
 threadpoolctl==3.5.0
     # via scikit-learn
 timeseriesutils @ git+https://github.com/reichlab/timeseriesutils@d25f33db30a8d5252329269ec9d205984f980f6c
@@ -190,14 +137,11 @@ toml==0.10.2
 tqdm==4.67.0
     # via
     #   idmodels (pyproject.toml)
-    #   covidcast
     #   numpyro
 tzdata==2024.2
     # via pandas
 urllib3==2.2.3
-    # via
-    #   botocore
-    #   requests
+    # via botocore
 wrapt==1.16.0
     # via aiobotocore
 yarl==1.17.1


### PR DESCRIPTION
I re-ran the `uv pip compile` command after having [updated sarix to remove covidcast as a dependency](https://github.com/elray1/sarix/commit/1c8995942d49afbb66637f0dc0662e1248606af4).

Recall that in the current status, the integration test for the gbqr model only passes on my machine.  I verified that it still passes locally on my machine after updating the installs:
```
==================================== 3 passed, 21 warnings in 99.39s (0:01:39) =====================================
```