### PR TITLE
Split main and training data sources into separate config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0]
+
+### Added
+- `supplementary_sources` field on `GBQRModelConfig` for combining NHSN and NSSP as additional training data alongside `main_source`
+- Tests covering `main_source` validation and `supplementary_sources` deduplication in `GBQRModel`/`SARIXModel._build_sources`
+
+### Changed
+- **Breaking**: `ModelConfig.sources` replaced by `ModelConfig.main_source` (a single `SourceType`); `main_source` determines output formatting (target name, unit conversion) while `GBQRModelConfig.supplementary_sources` lists any additional sources used only for model fitting
+- `GBQRModel`/`SARIXModel` output formatting (`_build_transform`, `_invert_transform`, `_format_output`) now keyed off `main_source` instead of scanning `sources`
+
+### Fixed
+- `GBQRModel` producing duplicate forecast rows when NHSN and NSSP were both present as sources; test-set filtering in `_train_gbq_and_predict()` now scopes to `main_source` instead of `source.isin(["nhsn", "nssp"])`
+
 ## [2.0.0]
 
 ### Added
@@ -130,7 +143,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated to latest iddata API
 
-[Unreleased]: https://github.com/reichlab/idmodels/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/reichlab/idmodels/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/reichlab/idmodels/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/reichlab/idmodels/compare/v1.3.1...v2.0.0
 [1.3.0]: https://github.com/reichlab/idmodels/compare/v1.1.0...v1.3.0
 [1.1.0]: https://github.com/reichlab/idmodels/compare/v1.0.0...v1.1.0

--- a/src/idmodels/__init__.py
+++ b/src/idmodels/__init__.py
@@ -25,4 +25,4 @@ __all__ = [
     "SourceType",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/src/idmodels/config.py
+++ b/src/idmodels/config.py
@@ -25,7 +25,7 @@ class ModelConfig(ABC):
     """Abstract base for model configuration."""
 
     model_name: str
-    sources: list[SourceType]
+    main_source: SourceType
     fit_locations_separately: bool
     power_transform: PowerTransform
 
@@ -73,6 +73,7 @@ class SARIXFourierModelConfig(SARIXModelConfig):
 
 @dataclass
 class GBQRModelConfig(ModelConfig):
+    training_sources: list[SourceType] = field(default_factory=list)
     incl_level_feats: bool = True
     num_bags: int = 100
     bag_frac_samples: float = 0.7

--- a/src/idmodels/config.py
+++ b/src/idmodels/config.py
@@ -73,7 +73,7 @@ class SARIXFourierModelConfig(SARIXModelConfig):
 
 @dataclass
 class GBQRModelConfig(ModelConfig):
-    training_sources: list[SourceType] = field(default_factory=list)
+    supplementary_sources: list[SourceType] = field(default_factory=list)
     incl_level_feats: bool = True
     num_bags: int = 100
     bag_frac_samples: float = 0.7

--- a/src/idmodels/gbqr.py
+++ b/src/idmodels/gbqr.py
@@ -43,7 +43,7 @@ class GBQRModel(IDModel):
                       SourceType.ILINET: ILINetDataSource(scale_to_positive=self.model_config.reporting_adj),
                       SourceType.FLUSURVNET: FluSurvNetDataSource(burden_adj=self.model_config.reporting_adj)}
         # concatenate + dedupe sources while preserving order so main_source is always first
-        all_sources = list(dict.fromkeys([self.model_config.main_source] + self.model_config.training_sources))
+        all_sources = list(dict.fromkeys([self.model_config.main_source] + self.model_config.supplementary_sources))
 
         # Check if both nhsn and nssp data are included as sources
         if self.model_config.main_source not in [SourceType.NHSN, SourceType.NSSP]:

--- a/src/idmodels/gbqr.py
+++ b/src/idmodels/gbqr.py
@@ -137,7 +137,7 @@ class GBQRModel(IDModel):
         cols_to_keep = ["source", "agg_level", "location", "wk_end_date", "pop", "inc_trans_cs", "horizon",
                         "inc_trans_center_factor", "inc_trans_scale_factor"]
         preds_df = df_test_w_preds[cols_to_keep + run_config.q_labels]
-        preds_df = preds_df.loc[preds_df["source"].isin(["nhsn", "nssp"])]
+        preds_df = preds_df.loc[preds_df["source"] == self.model_config.main_source.value]
         preds_df = pd.melt(preds_df,
                            id_vars=cols_to_keep,
                            var_name="output_type_id",

--- a/src/idmodels/gbqr.py
+++ b/src/idmodels/gbqr.py
@@ -42,11 +42,13 @@ class GBQRModel(IDModel):
                       SourceType.NSSP: NSSPDataSource(disease=run_config.disease),
                       SourceType.ILINET: ILINetDataSource(scale_to_positive=self.model_config.reporting_adj),
                       SourceType.FLUSURVNET: FluSurvNetDataSource(burden_adj=self.model_config.reporting_adj)}
-        # Check if both nhsn and nssp data are included as sources
-        if SourceType.NHSN in self.model_config.sources and SourceType.NSSP in self.model_config.sources:
-            raise ValueError("Only one of NHSN or NSSP may be selected.")
+        all_sources = list(dict.fromkeys([self.model_config.main_source] + self.model_config.training_sources))
 
-        return [source_map[s] for s in self.model_config.sources]
+        # Check if both nhsn and nssp data are included as sources
+        if self.model_config.main_source not in [SourceType.NHSN, SourceType.NSSP]:
+            raise ValueError("GBQRModel only supports NHSN and NSSP as main source.")
+
+        return [source_map[s] for s in all_sources]
 
 
     def _build_feature_pipeline(self, run_config: RunConfig) -> FeaturePipeline:

--- a/src/idmodels/gbqr.py
+++ b/src/idmodels/gbqr.py
@@ -42,6 +42,7 @@ class GBQRModel(IDModel):
                       SourceType.NSSP: NSSPDataSource(disease=run_config.disease),
                       SourceType.ILINET: ILINetDataSource(scale_to_positive=self.model_config.reporting_adj),
                       SourceType.FLUSURVNET: FluSurvNetDataSource(burden_adj=self.model_config.reporting_adj)}
+        # concatenate + dedupe sources while preserving order so main_source is always first
         all_sources = list(dict.fromkeys([self.model_config.main_source] + self.model_config.training_sources))
 
         # Check if both nhsn and nssp data are included as sources

--- a/src/idmodels/model.py
+++ b/src/idmodels/model.py
@@ -96,7 +96,7 @@ class IDModel(ABC):
             SourceType.ILINET: (ILINET_FLOOR, ILINET_SCALE),
             SourceType.FLUSURVNET: (FLUSURVNET_FLOOR, FLUSURVNET_SCALE),
         }
-        all_sources = [self.model_config.main_source] + getattr(self.model_config, "training_sources", [])
+        all_sources = [self.model_config.main_source] + getattr(self.model_config, "supplementary_sources", [])
         source_scale_params = {
             src.value: params
             for src, params in _SOURCE_SCALE_PARAMS.items()

--- a/src/idmodels/model.py
+++ b/src/idmodels/model.py
@@ -96,10 +96,11 @@ class IDModel(ABC):
             SourceType.ILINET: (ILINET_FLOOR, ILINET_SCALE),
             SourceType.FLUSURVNET: (FLUSURVNET_FLOOR, FLUSURVNET_SCALE),
         }
+        all_sources = [self.model_config.main_source] + getattr(self.model_config, "training_sources", [])
         source_scale_params = {
             src.value: params
             for src, params in _SOURCE_SCALE_PARAMS.items()
-            if src in self.model_config.sources
+            if src in all_sources
         }
         if self.model_config.power_transform == PowerTransform.FOURTH_ROOT:
             power_t: Transform = FourthRootTransform()
@@ -122,10 +123,10 @@ class IDModel(ABC):
         preds_df["value"] = transform.invert(preds_df["value"].values, context=preds_df)
         preds_df["value"] = np.maximum(preds_df["value"], 0.0)
 
-        if SourceType.NHSN in self.model_config.sources:
+        if self.model_config.main_source == SourceType.NHSN:
             # turn nhsn rates back into counts
             preds_df["value"] = preds_df["value"] * preds_df["pop"] / 100000
-        elif SourceType.NSSP in self.model_config.sources:
+        elif self.model_config.main_source == SourceType.NSSP:
             preds_df["value"] = np.minimum(preds_df["value"] / 100, 1.0)  # percentage to proportion
 
         return preds_df
@@ -133,9 +134,9 @@ class IDModel(ABC):
 
     def _format_output(self, preds_df: pd.DataFrame, run_config: RunConfig) -> pd.DataFrame:
         """Reshape to FluSight hub submission format."""
-        if SourceType.NHSN in self.model_config.sources:
+        if self.model_config.main_source == SourceType.NHSN:
             target_name = f"wk inc {run_config.disease.value} hosp"
-        else:
+        elif self.model_config.main_source == SourceType.NSSP:
             target_name = f"wk inc {run_config.disease.value} prop ed visits"
 
         preds_df["target_end_date"] = preds_df["wk_end_date"] + pd.to_timedelta(

--- a/src/idmodels/sarix.py
+++ b/src/idmodels/sarix.py
@@ -23,14 +23,10 @@ class SARIXModel(IDModel):
     def _build_sources(self, run_config: RunConfig):
         sources_map = {SourceType.NHSN: NHSNDataSource(disease=run_config.disease),
                        SourceType.NSSP: NSSPDataSource(disease=run_config.disease)}
-        if not set(self.model_config.sources) <= sources_map.keys():
-            raise ValueError("SARIXModel only supports NHSN and NSSP sources.")
+        if self.model_config.main_source not in sources_map:
+            raise ValueError("SARIXModel only supports NHSN and NSSP as main source.")
 
-        # Check if both nhsn and nssp data are included as sources
-        if SourceType.NHSN in self.model_config.sources and SourceType.NSSP in self.model_config.sources:
-            raise ValueError("Only one of NHSN or NSSP may be selected.")
-
-        return [sources_map[s] for s in self.model_config.sources]
+        return [sources_map[self.model_config.main_source]]
 
 
     def _build_feature_pipeline(self, run_config: RunConfig) -> FeaturePipeline:

--- a/tests/integration/test_gbqr.py
+++ b/tests/integration/test_gbqr.py
@@ -20,7 +20,7 @@ def test_gbqr_nhsn(make_run_config):
                   "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36",
                   "37", "38", "39", "40", "41", "42", "44", "45", "46", "47", "48", "49", "50", "51", "53", "54", "55",
                   "56", "72"]
-    model_config = create_test_gbqr_model_config(main_source=SourceType.NHSN, training_sources=[SourceType.FLUSURVNET, SourceType.ILINET])
+    model_config = create_test_gbqr_model_config(main_source=SourceType.NHSN, supplementary_sources=[SourceType.FLUSURVNET, SourceType.ILINET])
     run_config = make_run_config(ref_date=date, states=fips_codes, hsas=[])
 
     # patch lgb.LGBMRegressor's `predict()` to return the same values to make the tests reproducible across OSs
@@ -77,10 +77,10 @@ def test_gbqr_invalid_main_source_raises(make_run_config):
         GBQRModel(model_config)._build_sources(run_config)
 
 
-def test_gbqr_build_sources_dedupes_main_source_in_training_sources(make_run_config):
+def test_gbqr_build_sources_dedupes_main_source_in_supplementary_sources(make_run_config):
     model_config = create_test_gbqr_model_config(
         main_source=SourceType.NHSN,
-        training_sources=[SourceType.NHSN, SourceType.FLUSURVNET],
+        supplementary_sources=[SourceType.NHSN, SourceType.FLUSURVNET],
     )
     run_config = make_run_config(ref_date=datetime.date.fromisoformat("2024-01-06"), states=["US"], hsas=[])
 
@@ -98,7 +98,7 @@ def test_gbqr_test_set_predictions_filter_to_main_source(make_run_config):
     as main_source, the filter must be scoped to main_source -- otherwise both sources' rows
     survive into the output, producing duplicate (location, wk_end_date, horizon) rows.
     """
-    model_config = create_test_gbqr_model_config(main_source=SourceType.NSSP, training_sources=[SourceType.NHSN])
+    model_config = create_test_gbqr_model_config(main_source=SourceType.NSSP, supplementary_sources=[SourceType.NHSN])
     model_config.num_bags = 2
     model_config.bag_frac_samples = 1.0
     date = datetime.date.fromisoformat("2024-01-06")
@@ -135,7 +135,7 @@ def test_gbqr_test_set_predictions_filter_to_main_source(make_run_config):
     assert not preds_df.duplicated(subset=key_cols).any()
 
 
-def create_test_gbqr_model_config(main_source, training_sources=[]):
+def create_test_gbqr_model_config(main_source, supplementary_sources=[]):
     model_config = GBQRModelConfig(
         model_name="gbqr_" + main_source.value + "_no_reporting_adj",
 
@@ -150,7 +150,7 @@ def create_test_gbqr_model_config(main_source, training_sources=[]):
 
         # data sources and adjustments for reporting issues
         main_source=main_source,
-        training_sources=training_sources,
+        supplementary_sources=supplementary_sources,
 
         # fit locations separately or jointly
         fit_locations_separately=False,

--- a/tests/integration/test_gbqr.py
+++ b/tests/integration/test_gbqr.py
@@ -18,7 +18,7 @@ def test_gbqr_nhsn(make_run_config):
                   "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36",
                   "37", "38", "39", "40", "41", "42", "44", "45", "46", "47", "48", "49", "50", "51", "53", "54", "55",
                   "56", "72"]
-    model_config = create_test_gbqr_model_config(sources=[SourceType.FLUSURVNET, SourceType.NHSN, SourceType.ILINET])
+    model_config = create_test_gbqr_model_config(main_source=SourceType.NHSN, training_sources=[SourceType.FLUSURVNET, SourceType.ILINET])
     run_config = make_run_config(ref_date=date, states=fips_codes, hsas=[])
 
     # patch lgb.LGBMRegressor's `predict()` to return the same values to make the tests reproducible across OSs
@@ -40,7 +40,7 @@ def test_gbqr_nhsn(make_run_config):
 ])
 def test_gbqr_nssp(make_run_config, fips_codes, nci_ids):
     date = datetime.date.fromisoformat("2025-11-22")
-    model_config = create_test_gbqr_model_config(sources=[SourceType.NSSP])
+    model_config = create_test_gbqr_model_config(main_source=SourceType.NSSP)
     run_config = make_run_config(ref_date=date, states=fips_codes, hsas=nci_ids)
 
     # patch the `_np_percentile()` helper function return the same values to make the tests reproducible across OSs
@@ -67,14 +67,7 @@ def test_gbqr_nssp(make_run_config, fips_codes, nci_ids):
     assert_frame_equal(actual_df, expected_df)
 
 
-def create_test_gbqr_model_config(sources):
-    if SourceType.NHSN in sources:
-        main_source = SourceType.NHSN
-    elif SourceType.NSSP in sources:
-        main_source = SourceType.NSSP
-    else:
-        main_source = None
-
+def create_test_gbqr_model_config(main_source, training_sources=[]):
     model_config = GBQRModelConfig(
         model_name="gbqr_" + main_source.value + "_no_reporting_adj",
 
@@ -88,7 +81,8 @@ def create_test_gbqr_model_config(sources):
         reporting_adj=False,
 
         # data sources and adjustments for reporting issues
-        sources=sources,
+        main_source=main_source,
+        training_sources=training_sources,
 
         # fit locations separately or jointly
         fit_locations_separately=False,

--- a/tests/integration/test_gbqr.py
+++ b/tests/integration/test_gbqr.py
@@ -90,6 +90,51 @@ def test_gbqr_build_sources_dedupes_main_source_in_training_sources(make_run_con
     assert {type(s) for s in sources} == {NHSNDataSource, FluSurvNetDataSource}
 
 
+def test_gbqr_test_set_predictions_filter_to_main_source(make_run_config):
+    """
+    Regression test: _train_gbq_and_predict() used to keep test-set rows for source in
+    {"nhsn", "nssp"} unconditionally. That was only safe because a model's sources could not
+    include both NHSN and NSSP at once. Now that NHSN can be a training_source alongside NSSP
+    as main_source, the filter must be scoped to main_source -- otherwise both sources' rows
+    survive into the output, producing duplicate (location, wk_end_date, horizon) rows.
+    """
+    model_config = create_test_gbqr_model_config(main_source=SourceType.NSSP, training_sources=[SourceType.NHSN])
+    model_config.num_bags = 2
+    model_config.bag_frac_samples = 1.0
+    date = datetime.date.fromisoformat("2024-01-06")
+    run_config = make_run_config(ref_date=date, states=["01"], hsas=[])
+
+    dates = pd.to_datetime(["2023-12-16", "2023-12-23", "2023-12-30", "2024-01-06"])
+    rows = []
+    for source in ["nssp", "nhsn"]:
+        for i, wk_end_date in enumerate(dates):
+            is_test = wk_end_date == dates.max()
+            rows.append({
+                "source": source,
+                "agg_level": "state",
+                "location": "01",
+                "wk_end_date": wk_end_date,
+                "pop": 1_000_000,
+                "inc_trans_cs": 0.1 * (i + 1),
+                "horizon": 1,
+                "inc_trans_center_factor": 0.0,
+                "inc_trans_scale_factor": 1.0,
+                "season": "2023/24",
+                "season_week": 10,
+                "delta_target": None if is_test else 0.05 * (i + 1),
+                "feat1": float(i),
+            })
+    df = pd.DataFrame(rows)
+
+    model = GBQRModel(model_config)
+    with patch.object(lightgbm.sklearn.LGBMModel, "predict", return_value=numpy.array([0.1, 0.1])):
+        preds_df = model._fit_and_predict(df, feat_names=["feat1"], run_config=run_config)
+
+    assert set(preds_df["source"].unique()) == {"nssp"}
+    key_cols = ["location", "wk_end_date", "horizon", "output_type_id"]
+    assert not preds_df.duplicated(subset=key_cols).any()
+
+
 def create_test_gbqr_model_config(main_source, training_sources=[]):
     model_config = GBQRModelConfig(
         model_name="gbqr_" + main_source.value + "_no_reporting_adj",

--- a/tests/integration/test_gbqr.py
+++ b/tests/integration/test_gbqr.py
@@ -6,6 +6,8 @@ import lightgbm
 import numpy
 import pandas as pd
 import pytest
+from iddata.sources.flusurvnet import FluSurvNetDataSource
+from iddata.sources.nhsn import NHSNDataSource
 from pandas.testing import assert_frame_equal
 
 from idmodels.config import GBQRModelConfig, PowerTransform, SourceType
@@ -65,6 +67,27 @@ def test_gbqr_nssp(make_run_config, fips_codes, nci_ids):
                               f"UMass-{model_config.model_name}" /
                               f"{str(run_config.ref_date)}-UMass-{model_config.model_name}-{agg_level}.csv")
     assert_frame_equal(actual_df, expected_df)
+
+
+def test_gbqr_invalid_main_source_raises(make_run_config):
+    model_config = create_test_gbqr_model_config(main_source=SourceType.ILINET)
+    run_config = make_run_config(ref_date=datetime.date.fromisoformat("2024-01-06"), states=["US"], hsas=[])
+
+    with pytest.raises(ValueError, match="GBQRModel only supports NHSN and NSSP as main source."):
+        GBQRModel(model_config)._build_sources(run_config)
+
+
+def test_gbqr_build_sources_dedupes_main_source_in_training_sources(make_run_config):
+    model_config = create_test_gbqr_model_config(
+        main_source=SourceType.NHSN,
+        training_sources=[SourceType.NHSN, SourceType.FLUSURVNET],
+    )
+    run_config = make_run_config(ref_date=datetime.date.fromisoformat("2024-01-06"), states=["US"], hsas=[])
+
+    sources = GBQRModel(model_config)._build_sources(run_config)
+
+    assert len(sources) == 2
+    assert {type(s) for s in sources} == {NHSNDataSource, FluSurvNetDataSource}
 
 
 def create_test_gbqr_model_config(main_source, training_sources=[]):

--- a/tests/integration/test_gbqr_wave_features.py
+++ b/tests/integration/test_gbqr_wave_features.py
@@ -190,7 +190,7 @@ def test_gbqr_wave_features_with_model_config_pattern():
 
     # Simulate model_config with wave feature settings
     model_config = GBQRModelConfig(model_name="gbqr_wave_test",
-                                   sources=[SourceType.NHSN],
+                                   main_source=SourceType.NHSN,
                                    fit_locations_separately=False,
                                    power_transform=PowerTransform.FOURTH_ROOT,
                                    use_directional_waves=True,
@@ -234,7 +234,7 @@ def test_gbqr_wave_features_backwards_compatibility():
 
     # Model config WITHOUT wave feature settings (backwards compatibility)
     model_config = GBQRModelConfig(model_name="gbqr_no_waves",
-                                   sources=[SourceType.NHSN],
+                                   main_source=SourceType.NHSN,
                                    fit_locations_separately=False,
                                    power_transform=PowerTransform.FOURTH_ROOT,
                                    # use_directional_waves defaults to False

--- a/tests/integration/test_sarix.py
+++ b/tests/integration/test_sarix.py
@@ -23,7 +23,7 @@ def test_sarix_nhsn(make_run_config):
                   "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36",
                   "37", "38", "39", "40", "41", "42", "44", "45", "46", "47", "48", "49", "50", "51", "53", "54", "55",
                   "56", "72"]
-    model_config = create_test_sarix_model_config(main_source=[SourceType.NHSN], theta_pooling=PoolingStrategy.SHARED,
+    model_config = create_test_sarix_model_config(main_source=SourceType.NHSN, theta_pooling=PoolingStrategy.SHARED,
                                                   sigma_pooling=PoolingStrategy.NONE, num=200)
     run_config = make_run_config(ref_date=date, states=fips_codes, hsas=[])
 
@@ -47,7 +47,7 @@ def test_sarix_nhsn(make_run_config):
 ])
 def test_sarix_nssp(make_run_config, fips_codes, nci_ids):
     date = datetime.date.fromisoformat("2025-11-22")
-    model_config = create_test_sarix_model_config(main_source=[SourceType.NSSP], theta_pooling=PoolingStrategy.SHARED,
+    model_config = create_test_sarix_model_config(main_source=SourceType.NSSP, theta_pooling=PoolingStrategy.SHARED,
                                                   sigma_pooling=PoolingStrategy.NONE, num=200)
     run_config = make_run_config(ref_date=date, states=fips_codes, hsas=nci_ids)
 
@@ -79,7 +79,7 @@ def test_sarix_shared_sigma_pooling_multiple_batches(make_run_config):
     # Use multiple locations to ensure we have multiple batches
     date = datetime.date.fromisoformat("2024-01-06")
     fips_codes = ["US", "01", "02", "04", "05"]  # Multiple locs = multiple batches
-    model_config = create_test_sarix_model_config(main_source=[SourceType.NHSN], theta_pooling=PoolingStrategy.NONE,
+    model_config = create_test_sarix_model_config(main_source=SourceType.NHSN, theta_pooling=PoolingStrategy.NONE,
                                                   sigma_pooling=PoolingStrategy.SHARED, num=200)
     run_config = make_run_config(ref_date=date, states=fips_codes, hsas=[])
 
@@ -108,7 +108,7 @@ def test_sarix_fourier_none_pooling(make_run_config):
     """Test SARIXFourierModel with fourier_pooling='none' (unpooled)."""
     model_config = SARIXFourierModelConfig(
         model_name="sarix_p2_fourier_K2_none",
-        sources=[SourceType.NHSN],
+        main_source=SourceType.NHSN,
         fit_locations_separately=False,
         p=2,
         P=0,
@@ -126,7 +126,7 @@ def test_sarix_fourier_none_pooling(make_run_config):
 
     date = datetime.date.fromisoformat("2024-01-06")
     fips_codes = ["US", "01", "02", "04", "05"]  # fewer locs for faster testing
-    # model_config = create_test_sarix_model_config(main_source=[SourceType.NHSN], theta_pooling="shared", sigma_pooling="none")
+    # model_config = create_test_sarix_model_config(main_source=SourceType.NHSN, theta_pooling="shared", sigma_pooling="none")
     run_config = make_run_config(ref_date=date, states=fips_codes, hsas=[])
 
     model = SARIXFourierModel(model_config)
@@ -154,7 +154,7 @@ def test_sarix_fourier_shared_pooling(make_run_config):
     """Test SARIXFourierModel with fourier_pooling='shared' (pooled across locations)."""
     model_config = SARIXFourierModelConfig(
         model_name="sarix_p2_fourier_K2_shared",
-        sources=[SourceType.NHSN],
+        main_source=SourceType.NHSN,
         fit_locations_separately=False,
         p=2,
         P=0,
@@ -172,7 +172,7 @@ def test_sarix_fourier_shared_pooling(make_run_config):
 
     date = datetime.date.fromisoformat("2024-01-06")
     fips_codes = ["US", "01", "02", "04", "05"]  # fewer locs for faster testing
-    # model_config = create_test_sarix_model_config(main_source=[SourceType.NHSN], theta_pooling="shared", sigma_pooling="none")
+    # model_config = create_test_sarix_model_config(main_source=SourceType.NHSN, theta_pooling="shared", sigma_pooling="none")
     run_config = make_run_config(ref_date=date, states=fips_codes, hsas=[])
 
     model = SARIXFourierModel(model_config)
@@ -200,7 +200,7 @@ def test_sarix_fourier_wrong_config_type():
     """Test that SARIXFourierModel raises TypeError when given a SARIXModelConfig instead of SARIXFourierModelConfig."""
     model_config = SARIXModelConfig(
         model_name="sarix_p2",
-        sources=[SourceType.NHSN],
+        main_source=SourceType.NHSN,
         fit_locations_separately=False,
         p=2, P=0, d=0, D=0, season_period=1,
         power_transform=PowerTransform.FOURTH_ROOT,
@@ -216,11 +216,10 @@ def test_sarix_fourier_wrong_config_type():
 def create_test_sarix_model_config(main_source, theta_pooling: PoolingStrategy, sigma_pooling: PoolingStrategy,
                                    num: int = 200):
     model_config = SARIXModelConfig(
-        model_name="sarix_" + main_source[
-            0].value + "_p6_4rt_theta" + theta_pooling.value + "_sigma" + sigma_pooling.value,
+        model_name="sarix_" + main_source.value + "_p6_4rt_theta" + theta_pooling.value + "_sigma" + sigma_pooling.value,
 
         # data sources and adjustments for reporting issues
-        sources=main_source,
+        main_source=main_source,
 
         # fit locations separately or jointly
         fit_locations_separately=False,

--- a/tests/integration/test_sarix.py
+++ b/tests/integration/test_sarix.py
@@ -213,6 +213,15 @@ def test_sarix_fourier_wrong_config_type():
         SARIXFourierModel(model_config)
 
 
+def test_sarix_invalid_main_source_raises(make_run_config):
+    model_config = create_test_sarix_model_config(main_source=SourceType.ILINET, theta_pooling=PoolingStrategy.NONE,
+                                                  sigma_pooling=PoolingStrategy.NONE)
+    run_config = make_run_config(ref_date=datetime.date.fromisoformat("2024-01-06"), states=["US"], hsas=[])
+
+    with pytest.raises(ValueError, match="SARIXModel only supports NHSN and NSSP as main source."):
+        SARIXModel(model_config)._build_sources(run_config)
+
+
 def create_test_sarix_model_config(main_source, theta_pooling: PoolingStrategy, sigma_pooling: PoolingStrategy,
                                    num: int = 200):
     model_config = SARIXModelConfig(


### PR DESCRIPTION
**Main change:** Split the `source` field in model configs into two separate fields `main_source` and `training_sources`.

This change provides two primary benefits:
1. *Allows the creation of a (gbqr) model that uses both NSSP and NHSN data to inform its forecasts* (like UMass-Alloy). When we first implemented support for NSSP, we tried making the fewest changes and fitting the new functionality within the old framework; this involved assuming only one of NHSN and NSSP would be used for forecasting.
2. *Makes the designation of a main data source explicit instead of implicit.* We already would select one data source out of NHSN and NSSP to make and keep forecasts for if multiple data sources were specified, but this was hard-coded and not something exposed to the user. 

As we expand the capabilities of this pipeline to ingest more data sources and produce forecasts using more types of models, it will be useful to have these two fields split to be clearer about what the code is doing and allow more data sources to be selected as the main source for forecasting.